### PR TITLE
Collection | Update `expectedException`s annotations to method calls

### DIFF
--- a/AbstractCollection.php
+++ b/AbstractCollection.php
@@ -82,7 +82,7 @@ abstract class AbstractCollection implements CollectionInterface
         } else {
             $this->elements[$offset] = $element;
 
-            if (!$this->isAssociative && (!\is_int($offset) || $offset < 0 || $offset > \count($this->elements))) {
+            if (!$this->isAssociative && (!\is_numeric($offset) || $offset < 0 || $offset > \count($this->elements))) {
                 $this->isAssociative = true;
             }
         }
@@ -90,7 +90,7 @@ abstract class AbstractCollection implements CollectionInterface
 
     public function offsetUnset($offset): void
     {
-        if (!$this->isAssociative && \is_int($offset) && $offset < \count($this->elements) - 1) {
+        if (!$this->isAssociative && \is_numeric($offset) && $offset < \count($this->elements) - 1) {
             $this->isAssociative = true;
         }
 

--- a/Tests/CarCollectionTest.php
+++ b/Tests/CarCollectionTest.php
@@ -75,6 +75,7 @@ class CarCollectionTest extends TestCase
     public function testInvalidElementAddedToCollection(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         $cars = new CarCollection();
         $cars[] = new Car();
         $cars[] = new Human();
@@ -83,18 +84,21 @@ class CarCollectionTest extends TestCase
     public function testInvalidElementPassedToCollectionConstructor(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         new CarCollection([new Car(), new Human()]);
     }
 
     public function testInvalidTypePassedToCollectionConstructor(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         new CarCollection([new Car(), 'x']);
     }
 
     public function testRetrieveByInvalidKey(): void
     {
         $this->expectException(InvalidKeyException::class);
+
         $cars = new CarCollection(['A' => new Car('Porsche')]);
 
         $cars['X'];
@@ -178,6 +182,7 @@ class CarCollectionTest extends TestCase
     public function testInvalidMerge(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         $a = new Car('Porsche');
         $b = new Human();
         $cars = new CarCollection([$a]);
@@ -204,6 +209,7 @@ class CarCollectionTest extends TestCase
     public function testInvalidAppend(): void
     {
         $this->expectException(ProtectedKeyException::class);
+
         $a = new Car('Porsche');
         $b = new Car('BMW');
         $cars = new CarCollection([1 => $a]);

--- a/Tests/CarCollectionTest.php
+++ b/Tests/CarCollectionTest.php
@@ -2,6 +2,9 @@
 
 namespace Aircury\Collection\Tests;
 
+use Aircury\Collection\Exceptions\InvalidKeyException;
+use Aircury\Collection\Exceptions\ProtectedKeyException;
+use Aircury\Collection\Exceptions\UnexpectedElementException;
 use Aircury\Collection\Tests\Fixtures\Car;
 use Aircury\Collection\Tests\Fixtures\CarCollection;
 use Aircury\Collection\Tests\Fixtures\Human;
@@ -69,37 +72,29 @@ class CarCollectionTest extends TestCase
         $this->assertCount(2, $cars);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidElementAddedToCollection(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         $cars = new CarCollection();
         $cars[] = new Car();
         $cars[] = new Human();
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidElementPassedToCollectionConstructor(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         new CarCollection([new Car(), new Human()]);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidTypePassedToCollectionConstructor(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         new CarCollection([new Car(), 'x']);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\InvalidKeyException
-     */
     public function testRetrieveByInvalidKey(): void
     {
+        $this->expectException(InvalidKeyException::class);
         $cars = new CarCollection(['A' => new Car('Porsche')]);
 
         $cars['X'];
@@ -180,11 +175,9 @@ class CarCollectionTest extends TestCase
         $this->assertEquals('BMW', $cars[1]->getMake());
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidMerge(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         $a = new Car('Porsche');
         $b = new Human();
         $cars = new CarCollection([$a]);
@@ -208,11 +201,9 @@ class CarCollectionTest extends TestCase
         $this->assertFalse($cars->isAssociative());
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\ProtectedKeyException
-     */
     public function testInvalidAppend(): void
     {
+        $this->expectException(ProtectedKeyException::class);
         $a = new Car('Porsche');
         $b = new Car('BMW');
         $cars = new CarCollection([1 => $a]);

--- a/Tests/CollectionDiffTest.php
+++ b/Tests/CollectionDiffTest.php
@@ -137,6 +137,6 @@ class CollectionDiffTest extends TestCase
         $carsAfterApplied = $carDiff->apply($cars);
 
         $this->assertCount(3, $carsAfterApplied);
-        $this->assertEquals($otherCars->toArray(), $carsAfterApplied->toArray(), '', 0.0, 10, true);
+        $this->assertEqualsCanonicalizing($otherCars->toArray(), $carsAfterApplied->toArray(), '');
     }
 }

--- a/Tests/IntegerCollectionTest.php
+++ b/Tests/IntegerCollectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Aircury\Collection\Tests;
 
+use Aircury\Collection\Exceptions\InvalidKeyException;
+use Aircury\Collection\Exceptions\UnexpectedElementException;
 use Aircury\Collection\IntegerCollection;
 use Aircury\Collection\Tests\Fixtures\Car;
 use PHPUnit\Framework\TestCase;
@@ -44,47 +46,37 @@ class IntegerCollectionTest extends TestCase
         $this->assertCount(3, $integers);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidElementAddedToCollection(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         $integers = new IntegerCollection();
         $integers[] = 3;
         $integers[] = 'a';
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testNullElementAddedToCollection(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         $integers = new IntegerCollection();
         $integers[] = 3;
         $integers[] = null;
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidElementPassedToCollectionConstructor(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         new IntegerCollection([3, 7.2]);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidTypePassedToCollectionConstructor(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         new IntegerCollection([42, new Car('Volvo')]);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\InvalidKeyException
-     */
     public function testRetrieveByInvalidKey(): void
     {
+        $this->expectException(InvalidKeyException::class);
         $integers = new IntegerCollection(['A' => 3]);
 
         $integers['X'];

--- a/Tests/IntegerCollectionTest.php
+++ b/Tests/IntegerCollectionTest.php
@@ -49,6 +49,7 @@ class IntegerCollectionTest extends TestCase
     public function testInvalidElementAddedToCollection(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         $integers = new IntegerCollection();
         $integers[] = 3;
         $integers[] = 'a';
@@ -57,6 +58,7 @@ class IntegerCollectionTest extends TestCase
     public function testNullElementAddedToCollection(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         $integers = new IntegerCollection();
         $integers[] = 3;
         $integers[] = null;
@@ -65,18 +67,21 @@ class IntegerCollectionTest extends TestCase
     public function testInvalidElementPassedToCollectionConstructor(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         new IntegerCollection([3, 7.2]);
     }
 
     public function testInvalidTypePassedToCollectionConstructor(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         new IntegerCollection([42, new Car('Volvo')]);
     }
 
     public function testRetrieveByInvalidKey(): void
     {
         $this->expectException(InvalidKeyException::class);
+
         $integers = new IntegerCollection(['A' => 3]);
 
         $integers['X'];

--- a/Tests/IntegerOrNullCollectionTest.php
+++ b/Tests/IntegerOrNullCollectionTest.php
@@ -49,6 +49,7 @@ class IntegerOrNullCollectionTest extends TestCase
     public function testInvalidElementAddedToCollection(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         $integers = new IntegerOrNullCollection();
         $integers[] = 'a';
         $integers[] = 3;
@@ -70,18 +71,21 @@ class IntegerOrNullCollectionTest extends TestCase
     public function testInvalidElementPassedToCollectionConstructor(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         new IntegerOrNullCollection(['x', 42]);
     }
 
     public function testInvalidTypePassedToCollectionConstructor(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         new IntegerOrNullCollection([4, new Car('Volvo')]);
     }
 
     public function testRetrieveByInvalidKey(): void
     {
         $this->expectException(InvalidKeyException::class);
+
         $integers = new IntegerOrNullCollection(['A' => null]);
 
         $integers['X'];

--- a/Tests/IntegerOrNullCollectionTest.php
+++ b/Tests/IntegerOrNullCollectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Aircury\Collection\Tests;
 
+use Aircury\Collection\Exceptions\InvalidKeyException;
+use Aircury\Collection\Exceptions\UnexpectedElementException;
 use Aircury\Collection\IntegerOrNullCollection;
 use Aircury\Collection\Tests\Fixtures\Car;
 use PHPUnit\Framework\TestCase;
@@ -44,11 +46,9 @@ class IntegerOrNullCollectionTest extends TestCase
         $this->assertCount(3, $integers);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidElementAddedToCollection(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         $integers = new IntegerOrNullCollection();
         $integers[] = 'a';
         $integers[] = 3;
@@ -67,27 +67,21 @@ class IntegerOrNullCollectionTest extends TestCase
         $this->assertCount(3, $integers);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidElementPassedToCollectionConstructor(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         new IntegerOrNullCollection(['x', 42]);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidTypePassedToCollectionConstructor(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         new IntegerOrNullCollection([4, new Car('Volvo')]);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\InvalidKeyException
-     */
     public function testRetrieveByInvalidKey(): void
     {
+        $this->expectException(InvalidKeyException::class);
         $integers = new IntegerOrNullCollection(['A' => null]);
 
         $integers['X'];

--- a/Tests/StringCollectionTest.php
+++ b/Tests/StringCollectionTest.php
@@ -49,6 +49,7 @@ class StringCollectionTest extends TestCase
     public function testInvalidElementAddedToCollection(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         $strings = new StringCollection();
         $strings[] = 'a';
         $strings[] = 3;
@@ -57,6 +58,7 @@ class StringCollectionTest extends TestCase
     public function testNullElementAddedToCollection(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         $strings = new StringCollection();
         $strings[] = 'a';
         $strings[] = null;
@@ -65,18 +67,21 @@ class StringCollectionTest extends TestCase
     public function testInvalidElementPassedToCollectionConstructor(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         new StringCollection(['x', 42]);
     }
 
     public function testInvalidTypePassedToCollectionConstructor(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         new StringCollection(['x', new Car('Volvo')]);
     }
 
     public function testRetrieveByInvalidKey(): void
     {
         $this->expectException(InvalidKeyException::class);
+
         $strings = new StringCollection(['A' => 'a']);
 
         $strings['X'];

--- a/Tests/StringCollectionTest.php
+++ b/Tests/StringCollectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Aircury\Collection\Tests;
 
+use Aircury\Collection\Exceptions\InvalidKeyException;
+use Aircury\Collection\Exceptions\UnexpectedElementException;
 use Aircury\Collection\StringCollection;
 use Aircury\Collection\Tests\Fixtures\Car;
 use PHPUnit\Framework\TestCase;
@@ -44,47 +46,37 @@ class StringCollectionTest extends TestCase
         $this->assertCount(3, $strings);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidElementAddedToCollection(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         $strings = new StringCollection();
         $strings[] = 'a';
         $strings[] = 3;
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testNullElementAddedToCollection(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         $strings = new StringCollection();
         $strings[] = 'a';
         $strings[] = null;
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidElementPassedToCollectionConstructor(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         new StringCollection(['x', 42]);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidTypePassedToCollectionConstructor(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         new StringCollection(['x', new Car('Volvo')]);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\InvalidKeyException
-     */
     public function testRetrieveByInvalidKey(): void
     {
+        $this->expectException(InvalidKeyException::class);
         $strings = new StringCollection(['A' => 'a']);
 
         $strings['X'];

--- a/Tests/StringOrNullCollectionTest.php
+++ b/Tests/StringOrNullCollectionTest.php
@@ -49,6 +49,7 @@ class StringOrNullCollectionTest extends TestCase
     public function testInvalidElementAddedToCollection(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         $strings = new StringOrNullCollection();
         $strings[] = 'a';
         $strings[] = 3;
@@ -70,18 +71,21 @@ class StringOrNullCollectionTest extends TestCase
     public function testInvalidElementPassedToCollectionConstructor(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         new StringOrNullCollection(['x', 42]);
     }
 
     public function testInvalidTypePassedToCollectionConstructor(): void
     {
         $this->expectException(UnexpectedElementException::class);
+
         new StringOrNullCollection(['x', new Car('Volvo')]);
     }
 
     public function testRetrieveByInvalidKey(): void
     {
         $this->expectException(InvalidKeyException::class);
+
         $strings = new StringOrNullCollection(['A' => 'a']);
 
         $strings['X'];

--- a/Tests/StringOrNullCollectionTest.php
+++ b/Tests/StringOrNullCollectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Aircury\Collection\Tests;
 
+use Aircury\Collection\Exceptions\InvalidKeyException;
+use Aircury\Collection\Exceptions\UnexpectedElementException;
 use Aircury\Collection\StringOrNullCollection;
 use Aircury\Collection\Tests\Fixtures\Car;
 use PHPUnit\Framework\TestCase;
@@ -44,11 +46,9 @@ class StringOrNullCollectionTest extends TestCase
         $this->assertCount(3, $strings);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidElementAddedToCollection(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         $strings = new StringOrNullCollection();
         $strings[] = 'a';
         $strings[] = 3;
@@ -67,27 +67,21 @@ class StringOrNullCollectionTest extends TestCase
         $this->assertCount(3, $strings);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidElementPassedToCollectionConstructor(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         new StringOrNullCollection(['x', 42]);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\UnexpectedElementException
-     */
     public function testInvalidTypePassedToCollectionConstructor(): void
     {
+        $this->expectException(UnexpectedElementException::class);
         new StringOrNullCollection(['x', new Car('Volvo')]);
     }
 
-    /**
-     * @expectedException \Aircury\Collection\Exceptions\InvalidKeyException
-     */
     public function testRetrieveByInvalidKey(): void
     {
+        $this->expectException(InvalidKeyException::class);
         $strings = new StringOrNullCollection(['A' => 'a']);
 
         $strings['X'];


### PR DESCRIPTION
Update `@expectedException` annotations in order to use `$this->expectException` method calls