### PR TITLE
Collection | offsetGet fix

### DIFF
--- a/AbstractCollection.php
+++ b/AbstractCollection.php
@@ -62,7 +62,7 @@ abstract class AbstractCollection implements CollectionInterface
         return array_key_exists($offset, $this->elements);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (!isset($this->elements[$offset])) {
             throw InvalidKeyException::invalidOffset($offset, array_keys($this->elements));

--- a/CollectionInterface.php
+++ b/CollectionInterface.php
@@ -13,7 +13,7 @@ interface CollectionInterface extends \ArrayAccess, \Countable, \IteratorAggrega
 
     public function offsetSet($offset, $element): void;
 
-    public function offsetGet($offset);
+    public function offsetGet($offset): mixed;
 
     public function offsetUnset($offset): void;
 


### PR DESCRIPTION
To fix when running CEC's Process messages job:
```
[
  "exception" => ErrorException {
    #message: "Deprecated: Return type of Aircury\Collection\CollectionInterface::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice"
    #code: 0
    #file: "./vendor/aircury/collection/CollectionInterface.php"
    #line: 16
    #severity: E_DEPRECATED
    trace: {
      ./vendor/aircury/collection/CollectionInterface.php:16 { …}
      ./vendor/aircury/collection/CollectionInterface.php:5 { …}
      ./src/Logic/Messages/Processors/CommonMessageProcessor.php:37 {
        App\Logic\Messages\Processors\CommonMessageProcessor->execute(string $type = null, array $userIds = null): int
        › 
        › $messageTypes = $this->messageTypeFactory->getByAppAndType(static::APP, $type);
        › 
      }
      ./src/Command/MessageProcessCommand.php:111 { …}
      ./vendor/symfony/console/Command/Command.php:255 { …}
      ./vendor/symfony/console/Application.php:1039 { …}
      ./vendor/symfony/framework-bundle/Console/Application.php:97 { …}
      ./vendor/symfony/console/Application.php:275 { …}
      ./vendor/symfony/framework-bundle/Console/Application.php:83 { …}
      ./vendor/symfony/console/Application.php:149 { …}
      ./bin/console:42 { …}
    }
  }
]
```